### PR TITLE
Ignore folders generated by Bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _site
 .jekyll-metadata
 assets/css
 node_modules
+.bundle/
+vendor/


### PR DESCRIPTION
As specified in the official documentation:
https://jekyllrb.com/tutorials/using-jekyll-with-bundler/#commit-to-source-control