### PR TITLE
Use cross-spawn and cross-env to make the starter platform agnostic

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,9 +1,10 @@
+import purgecss from "@fullhuman/postcss-purgecss";
 import autoprefixer from "autoprefixer";
 import browserSync from "browser-sync";
+import spawn from "cross-spawn";
 import cssnano from "cssnano";
 import { dest, series, src, task, watch } from "gulp";
 import postcss from "gulp-postcss";
-import purgecss from "@fullhuman/postcss-purgecss";
 import atimport from "postcss-import";
 import tailwindcss from "tailwindcss";
 
@@ -13,16 +14,9 @@ const PRE_BUILD_STYLESHEET = "./src/style.css";
 const TAILWIND_CONFIG = "./tailwind.config.js";
 
 // Fix for Windows compatibility
-const isWindowsPlatform = process.platform === "win32";
-const jekyll = isWindowsPlatform ? "jekyll.bat" : "jekyll";
-const spawn = isWindowsPlatform
-  ? require("win-spawn")
-  : require("child_process").spawn;
+const jekyll = process.platform === "win32" ? "jekyll.bat" : "jekyll";
 
 const isDevelopmentBuild = process.env.NODE_ENV === "development";
-
-// Custom PurgeCSS Extractor for Tailwind CSS
-const purgeForTailwind = content => content.match(/[\w-/:]+(?<!:)/g) || [];
 
 task("buildJekyll", () => {
   browserSync.notify("Building Jekyll site...");
@@ -48,13 +42,13 @@ task("processStyles", () => {
           ? [
               purgecss({
                 content: [`${SITE_ROOT}/**/*.html`],
-                defaultExtractor: content =>
-                  content.match(/[\w-/:]+(?<!:)/g) || []
+                defaultExtractor: (content) =>
+                  content.match(/[\w-/:]+(?<!:)/g) || [],
               }),
               autoprefixer(),
-              cssnano()
+              cssnano(),
             ]
-          : [])
+          : []),
       ])
     )
     .pipe(dest(POST_BUILD_STYLESHEET));
@@ -68,9 +62,9 @@ task("startServer", () => {
     server: {
       baseDir: SITE_ROOT,
       serveStaticOptions: {
-        extensions: ["html"]
-      }
-    }
+        extensions: ["html"],
+      },
+    },
   });
 
   watch(
@@ -81,7 +75,7 @@ task("startServer", () => {
       "**/*.md",
       "**/*.markdown",
       "!_site/**/*",
-      "!node_modules/**/*"
+      "!node_modules/**/*",
     ],
     { interval: 500 },
     buildSite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1781,6 +1781,37 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+      "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -4913,6 +4944,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
@@ -6125,6 +6162,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "simple-swizzle": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "babel-preset-env": "1.7.0",
     "babel-register": "6.26.0",
     "browser-sync": "2.26.7",
+    "cross-env": "7.0.2",
+    "cross-spawn": "7.0.2",
     "cssnano": "4.1.10",
     "gulp": "4.0.2",
     "gulp-postcss": "8.0.0",
@@ -16,10 +18,10 @@
     "tailwindcss": "1.2.0"
   },
   "scripts": {
-    "build:production": "NODE_ENV=production gulp",
-    "build:dev": "NODE_ENV=development gulp",
+    "build:production": "cross-env NODE_ENV=production gulp",
+    "build:dev": "cross-env NODE_ENV=development gulp",
     "build": "npm run build:production",
-    "dev": "NODE_ENV=development gulp serve",
+    "dev": "cross-env NODE_ENV=development gulp serve",
     "start": "npm run dev"
   },
   "repository": {


### PR DESCRIPTION
Over the life of this starter, users have had issues with Windows compatibility: #64, #1, #72, #75. In an effort to make the starter more platform-agnostic, this PR pulls in [cross-env](https://github.com/kentcdodds/cross-env) and [cross-spawn](https://www.npmjs.com/package/cross-spawn).

Closes #75