### PR TITLE
Added netlify.toml to override build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A starter kit for using [Tailwind](https://tailwindcss.com) with [Jekyll](https:
 ## Deploy
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/taylorbryant/jekyll-starter-tailwind)
 
-Note: By default, Netlify uses `jekyll build` as the build command. Make sure to change this to `npm run build` or `npm run build:production`.
+Note: By default, Netlify uses `jekyll build` as the build command. The included `netlify.toml` file will override it to use `npm run build`.
 
 ## License
 [MIT](https://github.com/taylorbryant/jekyll-starter-tailwind/blob/master/LICENSE.md)

--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,4 @@ exclude:
   - README.md
   - src
   - tailwind.config.js
+  - netlify.toml

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "_site/"


### PR DESCRIPTION
The README correctly specifies that the Netlify build command must be changed, but this can be specified in a netlify.toml file (see [docs][netlify-docs]). This file needs to be ignored by the jekyll build, so the corresponding entry in _config.yml was also created.

[netlify-docs]:https://docs.netlify.com/configure-builds/file-based-configuration/#build-settings